### PR TITLE
Fix script for setting up MQ

### DIFF
--- a/scripts/setupMQ.sh
+++ b/scripts/setupMQ.sh
@@ -70,11 +70,11 @@ MQ_POD=$(kubectl get pods -l ${LABEL} -n ${MQ_NAMESPACE} -o jsonpath="{.items[0]
 
 echo "Sending MQ command file to MQ pod $MQ_POD"
 SCRIPTDIR=`dirname ${BASH_SOURCE[0]}`
-kubectl cp ${SCRIPTDIR}/defineStocktraderQueue.in $MQ_NAMESPACE/$MQ_POD:defineStocktraderQueue.in
+kubectl cp ${SCRIPTDIR}/defineStocktraderQueue.in $MQ_NAMESPACE/$MQ_POD:/tmp/defineStocktraderQueue.in
 
 # fix file permission
-kubectl exec -it $MQ_POD -n ${MQ_NAMESPACE} -- chmod 644 /defineStocktraderQueue.in
+kubectl exec -it $MQ_POD -n ${MQ_NAMESPACE} -- chmod 644 /tmp/defineStocktraderQueue.in
 
 # create queue
 echo "Creating MQ queue"
-kubectl exec -it $MQ_POD -n ${MQ_NAMESPACE} -- su - -c "runmqsc <defineStocktraderQueue.in" admin
+kubectl exec -it $MQ_POD -n ${MQ_NAMESPACE} -- su - -c "runmqsc < /tmp/defineStocktraderQueue.in" admin


### PR DESCRIPTION
The default user in the MQ docker instance doesn't have write permission
to the root directory now (due to changes to the PSP and Dockerfile). We
cannot copy files into the root directory.