### PR TITLE
Fix the template for stocktrader ConfigMap

### DIFF
--- a/stocktrader/templates/config.yaml
+++ b/stocktrader/templates/config.yaml
@@ -27,7 +27,12 @@ data:
   iex.url: {{ .Values.stockQuote.iexTrading }}
   odm.url: {{ .Values.odm.url }}
   openwhisk.url: {{ .Values.openwhisk.url }}
+{{- if Values.tradr.enabled }}
   ingress.address: {{ .Values.ingress.address }}
+{{- end }}
+{{- if Values.trader.enabled }}
+  trader.auth: {{ .Values.trader.auth }}
+{{- end }}
   kafka.address: {{ .Values.kafka.address }}
   kafka.topic: {{ .Values.kafka.topic }}
   database.kind: {{ .Values.database.kind }}

--- a/stocktrader/templates/tradr.yaml
+++ b/stocktrader/templates/tradr.yaml
@@ -158,8 +158,8 @@ spec:
         backend:
           serviceName: {{ .Release.Name }}-tradr-service
           servicePort: 3000
-{{- end }}
 ---
+{{- end }}
 {{- if .Values.global.route }}
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -177,5 +177,6 @@ spec:
     name: {{ .Release.Name }}-tradr-service
     weight: 100
   wildcardPolicy: None
+---
 {{- end }}
 {{- end }}

--- a/stocktrader/values.yaml
+++ b/stocktrader/values.yaml
@@ -135,3 +135,5 @@ mongo:
   password: <your Mongo password>
   database: <your Mongo database>
   authDB: <your Mongo auth database>
+ingress:
+  address: <address for the ingress>


### PR DESCRIPTION
The `ingress.address` is current referenced unconditionally even if it is not defined in values.yaml. This results in a deployment error.  Another related issue is that the `trader.auth` key is missing from the
ConfigMap, which is preventing the Pods from starting.