### PR TITLE
Clarify ODM version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Change values if necessary.
 
 ## Install and configure ODM
 
-**NOTE**: Currently only OCM version between 1.1.2 and 2.0.0 are supported.
+**NOTE**: Currently only OCM version between 1.1.0 and 2.1.0 are supported.
 
 1. Log in to your IBM Cloud Private management console.
 2. Click the `Catalog` button.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Change values if necessary.
 
 ## Install and configure ODM
 
+**NOTE**: Currently only OCM version between 1.1.2 and 2.0.0 are supported.
+
 1. Log in to your IBM Cloud Private management console.
 2. Click the `Catalog` button.
 3. Type `odm` into the search bar to find the IBM Operational Decision Manager (ODM) Helm chart.  Click on the chart.


### PR DESCRIPTION
We cannot use ODM version higher than 2.0.0. The decision service ZIP
file cannot be imported into newer versions of ODM.