### PR TITLE
Add 'quote' filter to password related credentials

### DIFF
--- a/stocktrader/templates/credentials.yaml
+++ b/stocktrader/templates/credentials.yaml
@@ -18,15 +18,15 @@ metadata:
   name: {{ .Release.Name }}-credentials
 stringData:
   database.id: {{ .Values.database.id }}
-  database.password: {{ .Values.database.password }}
+  database.password: {{ .Values.database.password | quote }}
   mq.id: {{ .Values.mq.id }}
-  mq.password: {{ .Values.mq.password }}
+  mq.password: {{ .Values.mq.password | quote }}
   odm.id: {{ .Values.odm.id }}
-  odm.password: {{ .Values.odm.password }}
+  odm.password: {{ .Values.odm.password | quote }}
   openwhisk.id: {{ .Values.openwhisk.id }}
-  openwhisk.password: {{ .Values.openwhisk.password }}
+  openwhisk.password: {{ .Values.openwhisk.password | quote }}
   watson.id: {{ .Values.watson.id }}
-  watson.password: {{ .Values.watson.passwordOrApiKey }}
+  watson.password: {{ .Values.watson.passwordOrApiKey | quote }}
   redis.url: {{ .Values.redis.urlWithCredentials }}
   oidc.clientId: {{ .Values.oidc.clientId }}
   oidc.clientSecret: {{ .Values.oidc.clientSecret }}
@@ -37,4 +37,4 @@ stringData:
   twitter.accessToken: {{ .Values.twitter.accessToken }}
   twitter.accessTokenSecret: {{ .Values.twitter.accessTokenSecret }}
   mongo.user: {{ .Values.mongo.user }}
-  mongo.password: {{ .Values.mongo.password }}
+  mongo.password: {{ .Values.mongo.password | quote }}


### PR DESCRIPTION
When performing "templating" (i.e. `helm template`), we hit the issue
related to null value conversion. This has been confirmed by the Helm
community. The workaround is to make sure that empty string values are
passed to the `quote` filter. This will ensure that we will always get
an empty string rather than a `null` value which is invalid for
Kubernetes.