### PR TITLE
Move the doc separators around

### DIFF
--- a/stocktrader/templates/looper.yaml
+++ b/stocktrader/templates/looper.yaml
@@ -96,8 +96,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
----
 {{- if .Values.global.autoscale }}
+---
 #Deploy the autoscaler
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -113,8 +113,8 @@ spec:
   maxReplicas: 10
   minReplicas: {{ .Values.global.replicas }}
   targetCPUUtilizationPercentage: 60
----
 {{- end }}
+---
 #Deploy the service
 apiVersion: v1
 kind: Service
@@ -140,8 +140,8 @@ spec:
       targetPort: 9443
   selector:
     app: looper
----
 {{- if .Values.global.ingress }}
+---
 #Configure the ingress
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -158,8 +158,8 @@ spec:
           serviceName: {{ .Release.Name }}-looper-service
           servicePort: 9080
 {{- end }}
----
 {{- if .Values.global.route }}
+---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/stocktrader/templates/notification-slack.yaml
+++ b/stocktrader/templates/notification-slack.yaml
@@ -99,8 +99,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
----
 {{- if .Values.global.autoscale }}
+---
 #Deploy the autoscaler
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler

--- a/stocktrader/templates/notification-twitter.yaml
+++ b/stocktrader/templates/notification-twitter.yaml
@@ -104,8 +104,8 @@ spec:
           requests:
             cpu: 250m
             memory: 256Mi
----
 {{- if .Values.global.autoscale }}
+---
 #Deploy the autoscaler
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler

--- a/stocktrader/templates/portfolio.yaml
+++ b/stocktrader/templates/portfolio.yaml
@@ -218,8 +218,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
----
 {{- if .Values.global.autoscale }}
+---
 #Deploy the autoscaler
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -235,8 +235,8 @@ spec:
   maxReplicas: 10
   minReplicas: {{ .Values.global.replicas }}
   targetCPUUtilizationPercentage: 60
----
 {{- end }}
+---
 #Deploy the service
 apiVersion: v1
 kind: Service
@@ -262,8 +262,8 @@ spec:
       targetPort: 9443
   selector:
     app: portfolio
----   
 {{- if .Values.global.ingress }}
+---   
 #Configure the ingress 
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/stocktrader/templates/stock-quote.yaml
+++ b/stocktrader/templates/stock-quote.yaml
@@ -106,8 +106,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
----
 {{- if .Values.global.autoscale }}
+---
 #Deploy the autoscaler
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -123,8 +123,8 @@ spec:
   maxReplicas: 10
   minReplicas: {{ .Values.global.replicas }}
   targetCPUUtilizationPercentage: 60
----
 {{- end }}
+---
 #Deploy the service
 apiVersion: v1
 kind: Service

--- a/stocktrader/templates/trade-history.yaml
+++ b/stocktrader/templates/trade-history.yaml
@@ -138,8 +138,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
----
 {{- if .Values.global.autoscale }}
+---
 #Deploy the autoscaler
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -155,8 +155,8 @@ spec:
   maxReplicas: 10
   minReplicas: {{ .Values.global.replicas }}
   targetCPUUtilizationPercentage: 60
----
 {{- end }}
+---
 #Deploy the service
 apiVersion: v1
 kind: Service
@@ -180,5 +180,4 @@ spec:
     port: 9443
   selector:
     app: trade-history
----
 {{- end }}

--- a/stocktrader/templates/trader.yaml
+++ b/stocktrader/templates/trader.yaml
@@ -132,8 +132,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
----
 {{- if .Values.global.autoscale }}
+---
 #Deploy the autoscaler
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -149,8 +149,8 @@ spec:
   maxReplicas: 10
   minReplicas: {{ .Values.global.replicas }}
   targetCPUUtilizationPercentage: 60
----
 {{- end }}
+---
 #Deploy the service
 apiVersion: v1
 kind: Service
@@ -176,8 +176,8 @@ spec:
       targetPort: 9443
   selector:
     app: trader
----
 {{- if .Values.global.ingress }}
+---
 #Configure the ingress
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -201,8 +201,8 @@ spec:
           serviceName: {{ .Release.Name }}-trader-service
           servicePort: 9443
 {{- end }}
----
 {{- if .Values.global.route }}
+---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/stocktrader/templates/tradr.yaml
+++ b/stocktrader/templates/tradr.yaml
@@ -105,8 +105,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
----
 {{- if .Values.global.autoscale }}
+---
 #Deploy the autoscaler
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -122,8 +122,8 @@ spec:
   maxReplicas: 10
   minReplicas: {{ .Values.global.replicas }}
   targetCPUUtilizationPercentage: 60
----
 {{- end }}
+---
 #Deploy the service
 apiVersion: v1
 kind: Service
@@ -137,8 +137,8 @@ spec:
     - port: 3000
   selector:
     app: tradr
----
 {{- if .Values.global.ingress }}
+---
 #Configure the ingress
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -164,8 +164,8 @@ spec:
           serviceName: {{ .Release.Name }}-tradr-service
           servicePort: 3000
 {{- end }}
----
 {{- if .Values.global.route }}
+---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:


### PR DESCRIPTION
When we are trying to extract different resources from the same YAML,
sometimes we got nil document because the doc separators (`---`) are
misplaced. This PR fixes it so that we always have the following
structure:

```
(some resources here ...)
{% if condition %}
---
apiVersion:
...
{% endif %}
```

Where the `---` is the first line starting a new document.