### PR TITLE
Add Amazon MQ (Apache ActiveMQ) support

### DIFF
--- a/stocktrader/templates/account.yaml
+++ b/stocktrader/templates/account.yaml
@@ -141,6 +141,11 @@ spec:
                 key: kafka.apiKey
                 optional: true
 {{- end }}
+          - name: MQ_KIND
+            valueFrom:
+              configMapKeyRef:
+                name: {{ tpl .Values.global.configMapName . }}
+                key: mq.kind
           - name: MQ_HOST
             valueFrom:
               configMapKeyRef:

--- a/stocktrader/templates/config.yaml
+++ b/stocktrader/templates/config.yaml
@@ -46,6 +46,7 @@ data:
   database.db: {{ .Values.database.db }}
   database.ssl: "{{ .Values.database.ssl }}"
   mq.host: {{ .Values.mq.host }}
+  mq.kind: {{ .Values.mq.kind }}
   mq.port: "{{ .Values.mq.port }}"
   mq.queueManager: {{ .Values.mq.queueManager }}
   mq.queue: {{ .Values.mq.queue }}

--- a/stocktrader/templates/messaging.yaml
+++ b/stocktrader/templates/messaging.yaml
@@ -90,6 +90,11 @@ spec:
                 name: {{ tpl .Values.global.secretName . }}
                 key: mq.password
 {{- end }}
+          - name: MQ_KIND
+            valueFrom:
+              configMapKeyRef:
+                name: {{ tpl .Values.global.configMapName . }}
+                key: mq.kind
           - name: MQ_HOST
             valueFrom:
               configMapKeyRef:

--- a/stocktrader/values-metadata.yaml
+++ b/stocktrader/values-metadata.yaml
@@ -896,12 +896,22 @@ odm:
       type: string
 mq:
   __metadata:
-    label: "IBM MQ settings (optional)"
+    label: "MQ settings (optional)"
     description: "Configuration for MQ.  Can be in-cluster, or external.  Needed only if you want to receive notifications about changes in loyalty level"
+  kind:
+    __metadata:
+      label: "Kind of MQ Provider"
+      description: "Choose from IBM MQ or Amazon MQ (Apache ActiveMQ)"
+      type: string
+      options:
+        - label: "IBM MQ"
+          value: "ibm-mq"
+        - label: "Amazon MQ (Apache ActiveMQ)"
+          value: "amazon-mq-apache-mq"
   host:
     __metadata:
       label: "Host"
-      description: "Host name, or IP address, for MQ.  Use the Kube DNS service name if using an intra-cluster deployment of MQ"
+      description: "Host name, IP address, or URL connection string for MQ.  Use the Kube DNS service name if using an intra-cluster deployment of MQ"
       type: string
   port:
     __metadata:
@@ -921,17 +931,17 @@ mq:
   queueManager:
     __metadata:
       label: "Queue Manager"
-      description: "Queue Manager to be used in MQ"
+      description: "Queue Manager to be used in IBM MQ"
       type: string
   queue:
     __metadata:
       label: "Queue"
-      description: "Queue to be used in MQ"
+      description: "Physical/Base Queue to be used in the MQ provider"
       type: string
   channel:
     __metadata:
       label: "Channel"
-      description: "Channel to be used in MQ"
+      description: "Channel to be used in IBM MQ"
       type: string
 redis:
   __metadata:

--- a/stocktrader/values.yaml
+++ b/stocktrader/values.yaml
@@ -197,6 +197,7 @@ odm:
   password: odmAdmin
   url: http://odmtrader1-ibm-odm-dev:9060/DecisionService/rest/ICP_Trader_Dev_1/determineLoyalty
 mq:
+  kind: ibm-mq
   host: mqtrader1-mqtrader1
   port: 1414
   id: app


### PR DESCRIPTION
This PR exposes MQ configuration values which were added to `account` which allows for specifying a non-IBM MQ messaging provider.
[https://github.com/IBMStockTrader/account/pull/4](
https://github.com/IBMStockTrader/account/pull/4)

Today, only IBM MQ and Amazon MQ (with Apache ActiveMQ as the implementation) are supported. More messaging providers could be added at a later date.